### PR TITLE
Enable acl allow execute always

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,33 @@
+image: docker:stable
+
+stages:
+  - build
+
+variables:
+  DOCKER_DRIVER: overlay2
+  CONTAINER_TEST_IMAGE: $CI_REGISTRY_IMAGE:$CI_COMMIT_REF_SLUG
+  CONTAINER_RELEASE_IMAGE: $CI_REGISTRY_IMAGE:latest
+  TRIVY_IMAGE: $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
+
+Kanikoize:
+  stage: build
+  image:
+    name: gcr.io/kaniko-project/executor:debug
+    entrypoint: [""]
+  script:
+    - |
+        mkdir -p /kaniko/.docker
+        echo "{\"auths\":{\"$CI_REGISTRY\":{\"username\":\"$CI_REGISTRY_USER\",\"password\":\"$CI_REGISTRY_PASSWORD\"}}}" > /kaniko/.docker/config.json
+        if [[ -z "$CI_COMMIT_TAG" ]]; then
+          /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile \
+            --destination $CONTAINER_TEST_IMAGE --destination $CONTAINER_RELEASE_IMAGE \
+            --destination $TRIVY_IMAGE
+        else
+          /kaniko/executor --context $CI_PROJECT_DIR --dockerfile $CI_PROJECT_DIR/Dockerfile \
+            --destination $CONTAINER_TEST_IMAGE --destination $CONTAINER_RELEASE_IMAGE \
+            --destination $TRIVY_IMAGE --destination "$CI_REGISTRY_IMAGE:$CI_COMMIT_TAG"
+        fi
+  only:
+    variables:
+      - ($CI_COMMIT_BRANCH == "master") || ($CI_COMMIT_TAG != "")
+  needs: []

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,9 @@ RUN apk --no-cache --no-progress upgrade && \
     echo '   server max protocol = SMB3' >>$file && \
     echo '   server min protocol = SMB2_10' >>$file && \
     echo '' >>$file && \
+    echo '   #Add execute bit' >>$file && \
+    echo '   acl allow execute always = True' >>$file && \
+    echo '' >>$file && \
     echo '   # Time Machine' >>$file && \
     echo '   fruit:delete_empty_adfiles = yes' >>$file && \
     echo '   fruit:time machine = yes' >>$file && \


### PR DESCRIPTION
This restores Samba's old behavior of allowing Windows files (.bat, .exe, etc) to be executable from a Samba share