### PR TITLE
Remove --log-stdout

### DIFF
--- a/samba.sh
+++ b/samba.sh
@@ -293,5 +293,5 @@ elif ps -ef | egrep -v grep | grep -q smbd; then
     echo "Service already running, please restart container to apply changes"
 else
     [[ ${NMBD:-""} ]] && ionice -c 3 nmbd -D
-    exec ionice -c 3 smbd -FS --no-process-group </dev/null
+    exec ionice -c 3 smbd --foreground --no-process-group </dev/null
 fi


### PR DESCRIPTION
Upstream Samba version is now 4.15.2 which patches https://www.samba.org/samba/security/CVE-2021-44142.html

In order to use the new version, we need to remove the -S argument per the new release:

> Release Notes for Samba 4.15.0
> All tools are now logging to stderr by default. You can use "--debug-stdout" to
> change the behavior. All servers will log to stderr at early startup until logging
> is setup to go to a file by default.