### PR TITLE
feat: Allow server to auto-negotiate max protocol

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,11 +40,8 @@ RUN apk --no-cache --no-progress upgrade && \
     echo '   recycle:versions = yes' >>$file && \
     echo '' >>$file && \
     echo '   # Security' >>$file && \
-    echo '   client ipc max protocol = SMB3' >>$file && \
     echo '   client ipc min protocol = SMB2_10' >>$file && \
-    echo '   client max protocol = SMB3' >>$file && \
     echo '   client min protocol = SMB2_10' >>$file && \
-    echo '   server max protocol = SMB3' >>$file && \
     echo '   server min protocol = SMB2_10' >>$file && \
     echo '' >>$file && \
     echo '   #Add execute bit' >>$file && \


### PR DESCRIPTION
Normally this option should not be set as the automatic negotiation phase in the SMB protocol takes care of choosing the appropriate protocol.

The value default refers to the latest supported protocol, currently SMB3_11.

https://www.samba.org/samba/docs/current/man-html/smb.conf.5.html