### PR TITLE
feat: Add tuning options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,10 @@ RUN apk --no-cache --no-progress upgrade && \
     echo '   printcap name = /dev/null' >>$file && \
     echo '   disable spoolss = yes' >>$file && \
     echo '   strict locking = no' >>$file && \
-    echo '   aio read size = 0' >>$file && \
-    echo '   aio write size = 0' >>$file && \
+    echo '   aio read size = 1' >>$file && \
+    echo '   aio write size = 1' >>$file && \
+    echo '   min receivefile size = 16384' >>$file && \
+    echo '   use sendfile = true' >>$file && \
     echo '   vfs objects = catia fruit recycle streams_xattr' >>$file && \
     echo '   recycle:keeptree = yes' >>$file && \
     echo '   recycle:maxsize = 0' >>$file && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN apk --no-cache --no-progress upgrade && \
     echo '   recycle:versions = yes' >>$file && \
     echo '' >>$file && \
     echo '   # Security' >>$file && \
+    echo '   smb encrypt = auto' >>$file && \
     echo '   client ipc min protocol = SMB2_10' >>$file && \
     echo '   client min protocol = SMB2_10' >>$file && \
     echo '   server min protocol = SMB2_10' >>$file && \

--- a/samba.sh
+++ b/samba.sh
@@ -293,5 +293,5 @@ elif ps -ef | egrep -v grep | grep -q smbd; then
     echo "Service already running, please restart container to apply changes"
 else
     [[ ${NMBD:-""} ]] && ionice -c 3 nmbd -D
-    exec ionice -c 3 smbd --foreground --no-process-group </dev/null
+    exec ionice -c 3 smbd -F --debug-stdout --no-process-group </dev/null
 fi


### PR DESCRIPTION
aio = read/write asynchronously

min receivefile size = Allow zero-copy writes directly from network socket buffers into the filesystem buffer cache

sendfile = some SMB read calls (mainly ReadAndX and ReadRaw) will use the more efficient sendfile system call for files that are exclusively oplocked